### PR TITLE
Add ignore annotation

### DIFF
--- a/demo/index.ts
+++ b/demo/index.ts
@@ -19,6 +19,14 @@ increment('not a number');`,
     }),
     copilotPlugin({
       apiKey: "d49954eb-cfba-4992-980f-d8fb37f0e942",
+      otherDocuments: [
+        {
+          absolutePath: "https://esm.town/v/foo.ts",
+          text: "export const foo = 10;",
+          language: Language.TYPESCRIPT,
+          editorLanguage: "typescript",
+        },
+      ],
     }),
   ],
   parent: document.querySelector("#editor")!,

--- a/src/annotations.ts
+++ b/src/annotations.ts
@@ -1,3 +1,10 @@
 import { Annotation } from "@codemirror/state";
 
 export const copilotEvent = Annotation.define<null>();
+
+/**
+ * Annotation that signals to upstream integrations
+ * that this transaction should not be included
+ * in history or treated otherwise as a user edit.
+ */
+export const copilotIgnore = Annotation.define<null>();

--- a/src/codeium.ts
+++ b/src/codeium.ts
@@ -49,7 +49,7 @@ export async function getCodeiumCompletions({
         tabSize: 2n,
         insertSpaces: true,
       },
-      otherDocuments: [],
+      otherDocuments: config.otherDocuments,
       multilineConfig: undefined,
     },
     {

--- a/src/completionRequester.ts
+++ b/src/completionRequester.ts
@@ -12,7 +12,7 @@ import {
   clearSuggestion,
 } from "./effects.js";
 import { completionDecoration } from "./completionDecoration.js";
-import { copilotEvent } from "./annotations.js";
+import { copilotEvent, copilotIgnore } from "./annotations.js";
 import { codeiumConfig } from "./config.js";
 
 /**
@@ -135,6 +135,7 @@ export function completionRequester() {
             })),
           }),
           annotations: [
+            copilotIgnore.of(null),
             copilotEvent.of(null),
             Transaction.addToHistory.of(false),
           ],

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,7 @@
 import { Facet, combineConfig } from "@codemirror/state";
 import { Language } from "./api/proto/exa/codeium_common_pb/codeium_common_pb.js";
+import { Document } from "./api/proto/exa/language_server_pb/language_server_pb.js";
+import { type PartialMessage } from "@bufbuild/protobuf";
 
 export interface CodeiumConfig {
   /**
@@ -14,6 +16,8 @@ export interface CodeiumConfig {
   timeout?: number;
 
   authSource?: number;
+
+  otherDocuments?: PartialMessage<Document>[];
 }
 
 export const codeiumConfig = Facet.define<
@@ -26,6 +30,7 @@ export const codeiumConfig = Facet.define<
       {
         language: Language.TYPESCRIPT,
         timeout: 150,
+        otherDocuments: [],
       },
       {},
     );

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -57,7 +57,7 @@ function viewCompletionPlugin() {
   });
 }
 
-export { Language };
+export { Language, copilotIgnore };
 
 export function copilotPlugin(config: CodeiumConfig): Extension {
   return [


### PR DESCRIPTION
Adds `shouldTakeUpdate` method, as well as `copilotIgnore` annotation, to make it safer for upstream consumers to receive events.

Also adds `otherDocuments` option.