### PR TITLE
Split otherDocuments configuration from the rest

### DIFF
--- a/demo/index.ts
+++ b/demo/index.ts
@@ -1,6 +1,10 @@
 import { EditorView, basicSetup } from "codemirror";
 import { javascript } from "@codemirror/lang-javascript";
-import { Language, copilotPlugin } from "../src/plugin.js";
+import {
+  codeiumOtherDocumentsConfig,
+  Language,
+  copilotPlugin,
+} from "../src/plugin.js";
 import { python } from "@codemirror/lang-python";
 
 new EditorView({
@@ -17,16 +21,20 @@ increment('not a number');`,
       typescript: true,
       jsx: true,
     }),
-    copilotPlugin({
-      apiKey: "d49954eb-cfba-4992-980f-d8fb37f0e942",
+    codeiumOtherDocumentsConfig.of({
       otherDocuments: [
         {
           absolutePath: "https://esm.town/v/foo.ts",
-          text: "export const foo = 10;",
+          text: `export const foo = 10;
+
+const hiddenValue = "https://macwright.com/"`,
           language: Language.TYPESCRIPT,
           editorLanguage: "typescript",
         },
       ],
+    }),
+    copilotPlugin({
+      apiKey: "d49954eb-cfba-4992-980f-d8fb37f0e942",
     }),
   ],
   parent: document.querySelector("#editor")!,

--- a/src/codeium.ts
+++ b/src/codeium.ts
@@ -1,9 +1,13 @@
 import { createPromiseClient } from "@connectrpc/connect";
 import { LanguageServerService } from "./api/proto/exa/language_server_pb/language_server_connect.js";
 import { createConnectTransport } from "@connectrpc/connect-web";
-import { GetCompletionsResponse } from "./api/proto/exa/language_server_pb/language_server_pb.js";
+import {
+  Document,
+  GetCompletionsResponse,
+} from "./api/proto/exa/language_server_pb/language_server_pb.js";
 import { CodeiumConfig } from "./config.js";
 import { ChangeSpec } from "@codemirror/state";
+import { type PartialMessage } from "@bufbuild/protobuf";
 
 // This is the same as the monaco editor example
 const transport = createConnectTransport({
@@ -19,10 +23,12 @@ export async function getCodeiumCompletions({
   text,
   cursorOffset,
   config,
+  otherDocuments,
 }: {
   text: string;
   cursorOffset: number;
   config: CodeiumConfig;
+  otherDocuments: PartialMessage<Document>[];
 }) {
   return (await client.getCompletions(
     {
@@ -49,7 +55,7 @@ export async function getCodeiumCompletions({
         tabSize: 2n,
         insertSpaces: true,
       },
-      otherDocuments: config.otherDocuments,
+      otherDocuments: otherDocuments,
       multilineConfig: undefined,
     },
     {

--- a/src/completionRequester.ts
+++ b/src/completionRequester.ts
@@ -13,7 +13,7 @@ import {
 } from "./effects.js";
 import { completionDecoration } from "./completionDecoration.js";
 import { copilotEvent, copilotIgnore } from "./annotations.js";
-import { codeiumConfig } from "./config.js";
+import { codeiumConfig, codeiumOtherDocumentsConfig } from "./config.js";
 
 /**
  * To request a completion, the document needs to have been
@@ -61,6 +61,9 @@ export function completionRequester() {
 
   return EditorView.updateListener.of((update: ViewUpdate) => {
     const config = update.view.state.facet(codeiumConfig);
+    const { otherDocuments } = update.view.state.facet(
+      codeiumOtherDocumentsConfig,
+    );
 
     if (!shouldRequestCompletion(update)) return;
 
@@ -89,6 +92,7 @@ export function completionRequester() {
           text: source,
           cursorOffset: pos,
           config,
+          otherDocuments,
         });
 
         if (
@@ -129,8 +133,6 @@ export function completionRequester() {
             suggestions: simplifyCompletions(completionResult).map((part) => {
               try {
                 return {
-                  displayText: part.text,
-                  endReplacement: 0, // "",
                   text: part.text,
                   cursorPos: pos,
                   startPos: combinedOffset + Number(part.offset),

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,8 +16,6 @@ export interface CodeiumConfig {
   timeout?: number;
 
   authSource?: number;
-
-  otherDocuments?: PartialMessage<Document>[];
 }
 
 export const codeiumConfig = Facet.define<
@@ -30,6 +28,24 @@ export const codeiumConfig = Facet.define<
       {
         language: Language.TYPESCRIPT,
         timeout: 150,
+      },
+      {},
+    );
+  },
+});
+
+export interface CodeiumOtherDocumentsConfig {
+  otherDocuments?: PartialMessage<Document>[];
+}
+
+export const codeiumOtherDocumentsConfig = Facet.define<
+  CodeiumOtherDocumentsConfig,
+  Required<CodeiumOtherDocumentsConfig>
+>({
+  combine(configs) {
+    return combineConfig<Required<CodeiumOtherDocumentsConfig>>(
+      configs,
+      {
         otherDocuments: [],
       },
       {},

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -7,7 +7,11 @@ import {
   rejectSuggestionCommand,
   acceptSuggestionCommand,
 } from "./commands.js";
-import { CodeiumConfig, codeiumConfig } from "./config.js";
+import {
+  CodeiumConfig,
+  codeiumConfig,
+  codeiumOtherDocumentsConfig,
+} from "./config.js";
 import { Language } from "./api/proto/exa/codeium_common_pb/codeium_common_pb.js";
 import { copilotIgnore } from "./annotations.js";
 
@@ -56,7 +60,7 @@ function viewCompletionPlugin() {
   });
 }
 
-export { Language, copilotIgnore };
+export { Language, copilotIgnore, codeiumConfig, codeiumOtherDocumentsConfig };
 
 export function copilotPlugin(config: CodeiumConfig): Extension {
   return [

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,11 +3,9 @@ import { type DecorationSet } from "@codemirror/view";
 
 export interface Suggestion {
   text: string;
-  displayText: string;
   cursorPos: number;
   startPos: number;
   endPos: number;
-  endReplacement: number;
 }
 
 export type CompletionState = null | {
@@ -17,11 +15,9 @@ export type CompletionState = null | {
 
 export interface GhostText {
   text: string;
-  displayText: string;
   displayPos: number;
   startPos: number;
   endGhostText: number;
-  endReplacement: number;
   endPos: number;
   decorations: DecorationSet;
 }


### PR DESCRIPTION
This:

- Cleans up some unused fields in internal data management
- Splits the otherDocuments config from the main plugin: I want to reconfigure those more often.