### PR TITLE
Reuse types across methods, keep all suggestions

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -4,6 +4,12 @@ import { copilotEvent, copilotIgnore } from "./annotations.js";
 import { completionDecoration } from "./completionDecoration.js";
 import { acceptSuggestion, clearSuggestion } from "./effects.js";
 
+/**
+ * Accepting a suggestion: we remove the ghost text, which
+ * was not part of CodeMirror history, and then re-add it,
+ * making sure that it _is_ added to history, and we remove
+ * the Decoration that was making that ghost text look ghostly.
+ */
 export function acceptSuggestionCommand(view: EditorView) {
   // We delete the ghost text and insert the suggestion.
   // We also set the cursor to the end of the suggestion.
@@ -47,6 +53,12 @@ export function acceptSuggestionCommand(view: EditorView) {
   return true;
 }
 
+/**
+ * Rejecting a suggestion: this looks at the currently-shown suggestion
+ * and reverses it, clears the suggestion, and makes sure
+ * that we don't add that clearing transaction to history and we don't
+ * trigger a new suggestion because of it.
+ */
 export function rejectSuggestionCommand(view: EditorView) {
   // We delete the suggestion, then carry through with the original keypress
   const stateField = view.state.field(completionDecoration);

--- a/src/completionDecoration.ts
+++ b/src/completionDecoration.ts
@@ -13,6 +13,12 @@ import type { CompletionState } from "./types.js";
 
 const ghostMark = Decoration.mark({ class: "cm-ghostText" });
 
+/**
+ * Note that the completion _text_ is not actually a decoration!
+ * The text is very real, and actually inserted into the editor.
+ * The completion decoration is just a decoration that matches
+ * the same range as the completion text, and changes how it looks.
+ */
 export const completionDecoration = StateField.define<CompletionState>({
   create(_state: EditorState) {
     return null;
@@ -24,10 +30,10 @@ export const completionDecoration = StateField.define<CompletionState>({
         // to refer to locations in the document _after_ we've
         // inserted the text.
         const decorations = Decoration.set(
-          effect.value.suggestions.map((suggestion) => {
+          effect.value.suggestions.map((suggestionRange) => {
             const range = ghostMark.range(
-              suggestion.startPos,
-              suggestion.endPos,
+              suggestionRange.absoluteStartPos,
+              suggestionRange.absoluteEndPos,
             );
             return range;
           }),

--- a/src/effects.ts
+++ b/src/effects.ts
@@ -1,10 +1,10 @@
 import { type ChangeSet, StateEffect } from "@codemirror/state";
-import type { Suggestion } from "./types.js";
+import type { SimpleChangeSpec } from "./types.js";
 
 // Effects to tell StateEffect what to do with GhostText
 export const addSuggestions = StateEffect.define<{
   reverseChangeSet: ChangeSet;
-  suggestions: Suggestion[];
+  suggestions: SimpleChangeSpec[];
 }>();
 export const acceptSuggestion = StateEffect.define<null>();
 export const clearSuggestion = StateEffect.define<null>();

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -85,6 +85,10 @@ export {
   type CodeiumConfig,
 };
 
+/**
+ * A combination of configuration, the keymap, the
+ * requester - as a composite extension for simplicity.
+ */
 export function copilotPlugin(config: CodeiumConfig): Extension {
   return [
     codeiumConfig.of(config),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,13 +1,6 @@
 import type { ChangeSet } from "@codemirror/state";
 import type { DecorationSet } from "@codemirror/view";
 
-export interface Suggestion {
-  text: string;
-  cursorPos: number;
-  startPos: number;
-  endPos: number;
-}
-
 export type CompletionState = null | {
   reverseChangeSet: ChangeSet;
   decorations: DecorationSet;
@@ -21,3 +14,16 @@ export interface GhostText {
   endPos: number;
   decorations: DecorationSet;
 }
+
+/**
+ * This is one of the variants of a ChangeSpec,
+ * plus the absoluteStartPos and absoluteEndPos
+ * properties.
+ */
+export type SimpleChangeSpec = {
+  absoluteStartPos: number;
+  absoluteEndPos: number;
+  from: number;
+  to: number;
+  insert: string;
+};


### PR DESCRIPTION
This works toward #11 - we were throwing away all suggestions but the first. This cleans up our types and lets us keep all the suggestions around.

We also, I think, can really simplify some of these types, and this PR does that - it removes some functional indirection.